### PR TITLE
Add conformance section

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,6 +133,7 @@
       more extensive tuning.
     </p>
   </section>
+  <section id="conformance"></section>
   <section data-link-for="MediaStreamTrack">
     <h2>Extension to MediaStreamTrack</h2>
     <pre class="idl">


### PR DESCRIPTION
Fixes one of the "Normative references in informative sections are not allowed" warnings messages reported by Respec.

The warning appeared because Respec assumes that a spec is informative-only in the absence of a conformance section, see discussion in:
https://github.com/w3c/respec/issues/2580