### PR TITLE
chore: fix ReSpec markdown error

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,13 +4,12 @@
 <head>
   <meta charset="utf-8">
   <title>MediaStreamTrack Content Hints</title>
-  <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
+  <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
   <script class='remove'>
   "use strict";
   // See https://github.com/w3c/respec/wiki/ for how to configure ReSpec
   var respecConfig = {
     "doRDFa": false,
-    "format": "markdown",
     "githubAPI": "https://api.github.com/repos/w3c/mst-content-hint",
     "issueBase": "https://www.github.com/w3c/mst-content-hint/issues/",
     "noLegacyStyle": true,


### PR DESCRIPTION
There have been some changes in markdown processing, which are incompatible with this document. Also, markdown is not used in the document, so removing it.

As an add-on, changed ReSpec script to lite jQuery-less version.