### PR TITLE
Add health warning on "text" constraint

### DIFF
--- a/index.html
+++ b/index.html
@@ -259,6 +259,10 @@
           text rendering.
           Artefacts from quantization or downscaling that make small text
           or line art unintelligible should be avoided.
+          <br>
+          Note that different scripts have different requirements on how detailed rendering
+          has to be in order to achieve legibility; this constraint doesn't generate any
+          guarantee that the text rendered will be legible for any particular script.
         </p></td></tr>
       </tbody></table>
     </section>


### PR DESCRIPTION
noting that it doesn't generate guarantees of legibility.
Fixes #35


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mst-content-hint/pull/56.html" title="Last updated on Oct 11, 2021, 1:20 PM UTC (13239bc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mst-content-hint/56/d18dee7...13239bc.html" title="Last updated on Oct 11, 2021, 1:20 PM UTC (13239bc)">Diff</a>