### PR TITLE
Improve markup of enumeration tables

### DIFF
--- a/index.html
+++ b/index.html
@@ -318,11 +318,14 @@
   "balanced"
 };</pre>
         <table data-link-for="RTCDegradationPreference" data-dfn-for=
-        "RTCDegradationPreference" class="simple">
-          <tbody>
+               "RTCDegradationPreference" class="simple">
+	  <caption>{{RTCDegradationPreference}} Enumeration description</caption>
+          <thead>
             <tr>
-              <th colspan="2">{{RTCDegradationPreference}} Enumeration description</th>
+	      <th>Enum value</th><th>Description</th>
             </tr>
+	  </thead>
+	  <tbody>
             <tr>
               <td data-tests="RTCRtpParameters-degradationPreference.html"><dfn data-idl>maintain-framerate</dfn></td>
               <td>


### PR DESCRIPTION
see also https://github.com/w3c/media-source/issues/307#issuecomment-1110865467


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 28, 2022, 2:12 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fmst-content-hint%2F42b212b8a3055f181de4177a6c8737a116fa7fc3%2Findex.html%3FisPreview%3Dtrue)

```
📡 HTTP Error 404: http://labs.w3.org/spec-generator/uploads/OgUMVe
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/mst-content-hint%2357.)._
</details>
