### PR TITLE
Fix implementation-defined reference to link to INFRA spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,10 +122,11 @@
   </section>
   <section id="terminology">
     <h2>Terminology</h2>
-    <p> The terms <dfn data-cite="!WEBRTC#dom-rtcrtpsender">RTCRtpSender</dfn>
-      and <dfn data-cite="!WEBRTC#dom-rtcrtpsendparameters">RTCRtpSendParameters</dfn>
-      are defined in [[!WEBRTC]].
-    </p>
+    <p>The terms <dfn data-cite="!WEBRTC#dom-rtcrtpsender">RTCRtpSender</dfn>
+    and <dfn data-cite="!WEBRTC#dom-rtcrtpsendparameters">
+    RTCRtpSendParameters</dfn> are defined in [[!WEBRTC]].</p>
+    <p>The term <dfn data-cite="!INFRA#implementation-defined">
+    implementation-defined</dfn> is defined in [[!INFRA]].</p>
   </section>
   <section data-link-for="MediaStreamTrack" id="mediastreamtrack-extension">
     <h2>Extension to MediaStreamTrack</h2>
@@ -308,7 +309,7 @@
       <p>
         When encoding video, the encoder is configured with a number of
         parameters; in this text, we'll call out resolution, framerate and
-        "encoding parameters"; the latter is implementation-defined, but can
+        "encoding parameters"; the latter is [=implementation-defined=], but can
         influence both the quality of the resulting video, the resources
         required to encode, and the bitrate that the video consumes. Here, we
         talk about it as if a higher value gives better quality, but higher

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
     "shortName": "mst-content-hint",
     "edDraftURI": "https://w3c.github.io/mst-content-hint/",
     "subjectPrefix": "[mst-content-hint]",
-    xref: ["mediacapture-streams"],
+    xref: ["mediacapture-streams", "webrtc", "infra"],
       group:           "webrtc",
       // name (without the @w3c.org) of the public mailing to which comments are due
       wgPublicList: "public-media-capture",
@@ -119,14 +119,6 @@
     </p>
   </section>
   <section id="conformance">
-  </section>
-  <section id="terminology">
-    <h2>Terminology</h2>
-    <p>The terms <dfn data-cite="!WEBRTC#dom-rtcrtpsender">RTCRtpSender</dfn>
-    and <dfn data-cite="!WEBRTC#dom-rtcrtpsendparameters">
-    RTCRtpSendParameters</dfn> are defined in [[!WEBRTC]].</p>
-    <p>The term <dfn data-cite="!INFRA#implementation-defined">
-    implementation-defined</dfn> is defined in [[!INFRA]].</p>
   </section>
   <section data-link-for="MediaStreamTrack" id="mediastreamtrack-extension">
     <h2>Extension to MediaStreamTrack</h2>


### PR DESCRIPTION
Fixes #64


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/mst-content-hint/pull/65.html" title="Last updated on Sep 19, 2025, 7:37 AM UTC (b22cd1f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mst-content-hint/65/40c0c1f...henbos:b22cd1f.html" title="Last updated on Sep 19, 2025, 7:37 AM UTC (b22cd1f)">Diff</a>